### PR TITLE
Tidying the HelpText properties in the command factories -- we don't

### DIFF
--- a/src/todo/CommandFactories/ArchiveCommandFactory.cs
+++ b/src/todo/CommandFactories/ArchiveCommandFactory.cs
@@ -13,8 +13,7 @@ public class ArchiveCommandFactory : CommandFactoryBase<ArchiveCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string [] HelpText => new[]
-    {
+    public override string [] HelpText { get; } = {
         "Archives the markdown file for a given date. The file is moved into the archive subfolder " +
         "of the main todo folder. The name of the archive folder is specified in settings.json. Also in " +
         "settings.json can be specified whether the file is moved simply in the file system, or by using " +

--- a/src/todo/CommandFactories/CommitCommandFactory.cs
+++ b/src/todo/CommandFactories/CommitCommandFactory.cs
@@ -11,8 +11,7 @@ public class CommitCommandFactory : CommandFactoryBase<CommitCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string [] HelpText => new[]
-    {
+    public override string [] HelpText { get; } = {
         "Gathers the current modifications into a commit. Commit message is optional.",
         "",
         "Usage: todo c [commit message]"

--- a/src/todo/CommandFactories/CreateOrShowDayListCommandFactory.cs
+++ b/src/todo/CommandFactories/CreateOrShowDayListCommandFactory.cs
@@ -13,8 +13,7 @@ public class CreateOrShowDayListCommandFactory : CommandFactoryBase<CreateOrShow
 
     public override bool IsDefaultCommandFactory => true;
 
-    public override string [] HelpText => new[]
-    {
+    public override string[] HelpText { get; } = {
         "Creates or shows a markdown file for the date supplied. " +
         "This is the default command and can be executed by typing anything that can be parsed as a date. " +
         "Supplying no date assumes the current day.",

--- a/src/todo/CommandFactories/ListFilesCommandFactory.cs
+++ b/src/todo/CommandFactories/ListFilesCommandFactory.cs
@@ -13,8 +13,7 @@ public class ListFilesCommandFactory : CommandFactoryBase<ListFilesCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string [] HelpText => new[]
-    {
+    public override string [] HelpText { get; } = {
         "Provides a list of all todo lists. Switches are as follows:-",
         "\tm -- main todo folder.",
         "\ta -- archive folder.",

--- a/src/todo/CommandFactories/PrintHtmlCommandFactory.cs
+++ b/src/todo/CommandFactories/PrintHtmlCommandFactory.cs
@@ -13,8 +13,7 @@ public class PrintHtmlCommandFactory : CommandFactoryBase<PrintHtmlCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string [] HelpText => new[]
-    {
+    public override string [] HelpText { get; } = {
         "Converts a Markdown file to HTML. Can be used with anything that can be parsed as a date. " +
         "Supplying no date performs this operation on the Markdown file for the current day.",
         "",

--- a/src/todo/CommandFactories/PushCommandFactory.cs
+++ b/src/todo/CommandFactories/PushCommandFactory.cs
@@ -12,8 +12,7 @@ public class PushCommandFactory : CommandFactoryBase<PushCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string[] HelpText => new[]
-    {
+    public override string[] HelpText { get; } = {
         "Executes a git push.",
         "",
         "Usage: todo push"

--- a/src/todo/CommandFactories/ShowHelpCommandFactory.cs
+++ b/src/todo/CommandFactories/ShowHelpCommandFactory.cs
@@ -12,8 +12,7 @@ public class ShowHelpCommandFactory : CommandFactoryBase<ShowHelpCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string[] HelpText => new[]
-    {
+    public override string[] HelpText { get; } = {
         "Displays this help screen.",
         "",
         "Usage: todo help"

--- a/src/todo/CommandFactories/ShowHtmlCommandFactory.cs
+++ b/src/todo/CommandFactories/ShowHtmlCommandFactory.cs
@@ -13,8 +13,7 @@ public class ShowHtmlCommandFactory : CommandFactoryBase<ShowHtmlCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string[] HelpText => new[]
-    {
+    public override string[] HelpText { get; } = {
         "Opens the browser specified in the settings file and loads the Html file for the given date.",
         "",
         "Usage: todo h [date]"

--- a/src/todo/CommandFactories/SyncCommandFactory.cs
+++ b/src/todo/CommandFactories/SyncCommandFactory.cs
@@ -11,8 +11,7 @@ public class SyncCommandFactory : CommandFactoryBase<SyncCommand>
 
     public override bool IsDefaultCommandFactory => false;
 
-    public override string[] HelpText => new[]
-    {
+    public override string[] HelpText { get; } = {
         "Executes a commit and push operation sequentially.",
         "",
         "Usage: todo s [commit message]"


### PR DESCRIPTION
want to create a new string array each time the property is accessed.