### PR TITLE
Changing default day-list-template so that the headings reflect the

### DIFF
--- a/src/todo/day-list-template.md
+++ b/src/todo/day-list-template.md
@@ -1,9 +1,10 @@
 # Todo list for {date}
 
-## Work
 
-* 
 
-## Personal
 
-* 
+## Carried forward
+
+## Not done
+
+## DONE


### PR DESCRIPTION
score categories in the default json settings file