### PR TITLE
Allow the current date to be overridden using an environment variable.

### DIFF
--- a/src/TodoTests/Config.cs
+++ b/src/TodoTests/Config.cs
@@ -17,7 +17,7 @@ public static class Config
         var todoListInfo = new TodoListInformation("Test list", true, true);
         
         var configuration = new Configuration(todoListInfo, blankPaths, blankPaths, "",
-            "", "", HtmlThemeEnum.Dark, "", "", "",
+            "", "", "", HtmlThemeEnum.Dark, "", "", "",
             true, true, new TimeSpan(4, 0, 0), 
             80, IterationMethodEnum.Parallel, 21, []);
         

--- a/src/todo/Contracts/Data/Config/Configuration.cs
+++ b/src/todo/Contracts/Data/Config/Configuration.cs
@@ -8,6 +8,7 @@ namespace Todo.Contracts.Data.Config;
 public record Configuration(TodoListInformation TodoListInfo,
     PerOsFilePaths BrowserPath, PerOsFilePaths TextEditorPath,
     string DayListMarkdownTemplatePath, string TopicListMarkdownTemplatePath,
+    string EnvironmentVariableToOverrideDate,
     string HtmlTemplatePath, HtmlThemeEnum HtmlTheme,
     string OutputFolder, string ArchiveFolderName, string TodoListFilenameFormatWithoutExension,
     bool UseNamesForDays, bool UseGit, TimeSpan? NewDayThreshold, int ConsoleWidth,

--- a/src/todo/Dates/DateAdjuster.cs
+++ b/src/todo/Dates/DateAdjuster.cs
@@ -10,7 +10,8 @@ public class DateAdjuster(IDateAccessor dateAccessor,
 {
     public DateOnly GetTodayWithMidnightAdjusted()
     {
-        var newDayThreshold = configurationProvider.ConfigInfo.Configuration.NewDayThreshold ?? new TimeSpan(0, 0, 0);
+        var newDayThreshold = configurationProvider.ConfigInfo.Configuration.NewDayThreshold 
+                              ?? new TimeSpan(0, 0, 0);
 
         var now = dateAccessor.GetNow();
         

--- a/src/todo/Dates/DateParser.cs
+++ b/src/todo/Dates/DateParser.cs
@@ -3,25 +3,30 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Todo.Contracts.Services.Dates;
+using Todo.Contracts.Services.StateAndConfig;
 
 namespace Todo.Dates;
 
-public class DateParser(IDateHelper dateHelper, IDateAdjuster dateAdjuster) : IDateParser
+public class DateParser(IConfigurationProvider configurationProvider, 
+    IDateHelper dateHelper, IDateAdjuster dateAdjuster) : IDateParser
 {
+    
     public bool TryGetDate(string? str, out DateOnly dateOnly)
     {
-        if (str is null)
-        {
-            dateOnly = default;
-            return false;
-        }
+        return EnvironmentVariableSetsOverride(out var overrideDate) 
+            ? TryGetDateRelativeTo(str, overrideDate, out dateOnly) 
+            : TryGetDateRelativeTo(str, dateAdjuster.GetTodayWithMidnightAdjusted(), out dateOnly);
+    }
 
+    private bool TryGetDateRelativeTo(string? str, DateOnly relativeToDate, out DateOnly dateOnly)
+    {
         //NOTE: order of these tests is important.
-
-        if (IsYesterday(str)) dateOnly = dateAdjuster.GetTodayWithMidnightAdjusted().AddDays(-1);
-        else if (IsToday(str)) dateOnly = dateAdjuster.GetTodayWithMidnightAdjusted();
-        else if (IsTomorrow(str)) dateOnly = dateAdjuster.GetTodayWithMidnightAdjusted().AddDays(1);
-        else if (IsRelativeOffset(str, out var offset)) dateOnly = dateAdjuster.GetTodayWithMidnightAdjusted().AddDays(offset);
+        
+        if (str is null) dateOnly = default;
+        else if (IsYesterday(str)) dateOnly = relativeToDate.AddDays(-1);
+        else if (IsToday(str)) dateOnly = relativeToDate;
+        else if (IsTomorrow(str)) dateOnly = relativeToDate.AddDays(1);
+        else if (IsRelativeOffset(str, out var offset)) dateOnly = relativeToDate.AddDays(offset);
         else if (IsDayOfWeek(str, out var dayOfWeek)) dateOnly = GetDateFromDayOfWeek((DayOfWeek)dayOfWeek!);
         else if (IsDayOnly(str, out var day)) dateOnly = GetDateFromDayOnly(day);
         else if (IsLastThisOrNext(str, out var dateFromColloquial)
@@ -34,8 +39,22 @@ public class DateParser(IDateHelper dateHelper, IDateAdjuster dateAdjuster) : ID
         return dateOnly != default;
     }
 
+    private bool EnvironmentVariableSetsOverride(out DateOnly overrideDate)
+    {
+        var environmentVariableName = configurationProvider.ConfigInfo
+            .Configuration.EnvironmentVariableToOverrideDate;
 
-
+        if (string.IsNullOrWhiteSpace(environmentVariableName))
+        {
+            overrideDate = default;
+            return false;
+        }
+        
+        var overrideDateStr = Environment.GetEnvironmentVariable(environmentVariableName);
+        
+        return TryGetDateRelativeTo(overrideDateStr, dateAdjuster.GetTodayWithMidnightAdjusted(), out overrideDate);
+    }
+    
     private static bool IsYesterday(string commandLine) => commandLine.ToLower() switch
     {
         "y" => true,

--- a/src/todo/todo-settings.json
+++ b/src/todo/todo-settings.json
@@ -34,7 +34,8 @@
   },
   "DayListMarkdownTemplatePath": "day-list-template.md",
   "TopicListMarkdownTemplatePath": "topic-list-template.md",
-  
+  "EnvironmentVariableToOverrideDate": "TODO_DATE", 
+          
   //Html settings
   "HtmlTemplatePath": "template.html",
   "HtmlTheme": "Dark",


### PR DESCRIPTION
This can be done by setting the environment variable for the whole session or by setting it simply on a per-run basis.

Also, the variable can itself contain items like "y" or "tm"