### PR TITLE
Ensuring that the consuming thread in output writer is created only when

### DIFF
--- a/src/Todo.Tests/CommandInterpretationTests.cs
+++ b/src/Todo.Tests/CommandInterpretationTests.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using Todo.Contracts.Data.Commands;
 using Todo.Contracts.Services.Dates;
 using Todo.Contracts.Services.StateAndConfig;
+using Todo.Contracts.Services.UI;
 
 namespace Todo.Tests;
 
@@ -44,6 +45,8 @@ public class CommandInterpretationTests
 
         var serviceProvider = GetServiceProvider(mockCommandLine);
 
+        using var handle = serviceProvider.GetRequiredService<IOutputWriter>().CreateDisposableHandle();
+        
         var commandProvider = serviceProvider.GetRequiredService<ICommandProvider>();
 
         var actualCommand = commandProvider.GetCommand();

--- a/src/Todo/UI/OutputWriter.cs
+++ b/src/Todo/UI/OutputWriter.cs
@@ -7,36 +7,46 @@ namespace Todo.UI;
 
 public class OutputWriter : IOutputWriter
 {
-    private readonly Thread _writingThread;
-    private readonly BlockingCollection<string> _pipe;
+    private bool _initialised;
+    private Thread? _writingThread;
+    private BlockingCollection<string>? _pipe;
 
-    public OutputWriter()
-    {
-        _pipe = new BlockingCollection<string>();
-        _writingThread = new Thread(ConsumingThread);
-        _writingThread.Start();
-    }
-    
     public void WriteLine() => WriteLine("");
 
     public void WriteLine(object obj) => WriteLine(obj.ToString() ?? "");
 
-    public void WriteLine(string message) => _pipe.Add(message);
+    public void WriteLine(string message)
+    {
+        CheckInitialised();
+        _pipe!.Add(message);
+    }
+
+    private void CheckInitialised()
+    {
+        if (!_initialised) throw new InvalidOperationException("Output writer is not initialised");
+    }
     
     public IOutputWriterDisposableHandle CreateDisposableHandle()
     {
+        _pipe = new BlockingCollection<string>();
+        _writingThread = new Thread(ConsumingThread);
+        _writingThread.Start();
+        _initialised = true;
+        
         return new OutputWriterDisposableHandle(this);
     }
 
     public void JoinWritingThread()
     {
-        _pipe.CompleteAdding();
-        _writingThread.Join();
+        if (!_initialised) throw new InvalidOperationException("Output writer is not initialised");
+
+        _pipe!.CompleteAdding();
+        _writingThread!.Join();
     }
 
     private void ConsumingThread()
     {
-        while (_pipe.TryTake(out var str, -1))
+        while (_pipe!.TryTake(out var str, -1))
         {
             Console.WriteLine(str);
         }


### PR DESCRIPTION
the handle is created. Not quite ideal but better